### PR TITLE
Add type checking CI

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,13 @@
+name: mypy type checker
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: jpetrucciani/mypy-check@master
+        with:
+          path: 'lnbits'


### PR DESCRIPTION
I noticed that some of the type annotations are violated an ran the mypy typechecker to see what else might be broken. I think it'd be a good idea to fix the obvious errors, try to improve annotations and mark the remaining errors as to-be-ignored. To continually test for type errors this PR adds a GitHub Action that runs mypy for every PR and push. [Here's the output of this PR.](https://github.com/sgeisler/lnbits/runs/616864506?check_suite_focus=true)

Once the project gains some tests these can be run automatically using actions too (through e.g. a second workflow step).